### PR TITLE
Stop using dropped classes in 1.42

### DIFF
--- a/GTagHooks.php
+++ b/GTagHooks.php
@@ -1,6 +1,7 @@
 <?php
 
 use MediaWiki\MediaWikiServices;
+use MediaWiki\ResourceLoader\Module;
 
 class GTagHooks {
 	/**
@@ -28,8 +29,8 @@ class GTagHooks {
 
 		// Determine if this is a sensitive page and we should not track it.
 		if ( !$trackSensitive ) {
-			$allowed = $out->getAllowedModules( ResourceLoaderModule::TYPE_SCRIPTS );
-			if ( $allowed < ResourceLoaderModule::ORIGIN_USER_SITEWIDE ) {
+			$allowed = $out->getAllowedModules( Module::TYPE_SCRIPTS );
+			if ( $allowed < Module::ORIGIN_USER_SITEWIDE ) {
 				// the current page is not allowing user-editable modules and we
 				// are configured to not track sensitive pages
 				return;


### PR DESCRIPTION
Per https://www.mediawiki.org/wiki/Release_notes/1.42#MediaWiki_1.42.1
- The old aliases for the namespaced ResourceLoader classes, deprecated since they were moved in MediaWiki 1.39, have now been dropped
- Need to now reference specific class
- Looks like this class has existed since 1.17 so there should be no breaks to currently supported versions