### PR TITLE
Load GTag after CookieConsent using script tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ tracking tag on your MediaWiki site (gtag.js).
 
 ## Requirements
 
-- MediaWiki 1.39 or later
+- MediaWiki 1.43 or later
 
 ## Installation
 
@@ -27,7 +27,7 @@ to your LocalSettings.php file.
 |------------------------------|---------|-----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `$wgGTagAnalyticsId`         | _none_  | Google Analytics ID or Google Tag Manager container ID, for example `'GT-NNVDXRX5'` or `'GTM-MG9RFZQQ'`. Required.                                        |
 | `$wgGTagAnonymizeIP`         | `false` | If true, [anonymize IP addresses sent to Google Analytics][5]. Ignored when operating in Google Tag Manager mode.                                         |
-| `$wgGTagEnableTCF`           | `false` | If true, enable support for the IAB Transparency & Consent Framework. Ignored when operating in Google Tag Manager mode.                                  |
+| `$wgGTagEnableTCF`           | `false` | If true, enable support for the IAB Transparency & Consent Framework. Ignored when CookieConsent is loaded, and when operating in Google Tag Manager mode. |
 | `$wgGTagHonorDNT`            | `false` | If true, honor "Do Not Track" requests from browsers. If false, ignore such requests.                                                                     |
 | `$wgGTagTrackSensitivePages` | `true`  | If true, insert tracking code into sensitive pages such as Special:UserLogin and Special:Preferences. If false, no tracking code is added to these pages. |
 
@@ -40,6 +40,15 @@ idea of who is actually using your site. For example:
 $wgGroupPermissions['sysop']['gtag-exempt'] = true;
 ```
 
+When [CookieConsent][6] is loaded, GTag emits Google scripts as `type="text/plain"` with `data-mw-cookieconsent="statistics"`. CookieConsent enables them after statistics consent. CookieConsent needs JavaScript, so GTM does not output the noscript iframe in this mode. Example:
+```php
+wfLoadExtension( 'CookieConsent' );
+wfLoadExtension( 'GTag' );
+$wgGTagAnalyticsId = 'G-XXXXXXXX';
+```
+
+**Warning:** Do not enable `$wgCookieConsentEnableGeolocation` if anonymous HTML is cached (MediaWiki file cache, Varnish, or Cloudflare HTML cache). The first visitor's country is then reused for everyone. With GTag, if that HTML has no CookieConsent JavaScript, Google stays `text/plain` and never starts.
+
 ## Support
 
 - For general community support questions, please make use of the [talk page on mediawiki.org][2].
@@ -51,3 +60,4 @@ $wgGroupPermissions['sysop']['gtag-exempt'] = true;
 [3]: https://github.com/SkizNet/mediawiki-GTag/issues
 [4]: https://store.skizzerz.net/store/mediawiki-support
 [5]: https://support.google.com/analytics/answer/2763052
+[6]: https://www.mediawiki.org/wiki/Extension:CookieConsent

--- a/extension.json
+++ b/extension.json
@@ -1,7 +1,7 @@
 {
 	"name": "GTag",
 	"namemsg": "gtag-extensionname",
-	"version": "1.4.0",
+	"version": "1.5.0",
 	"author": [
 		"Ryan Schmidt"
 	],
@@ -22,7 +22,7 @@
 		},
 		"GTagEnableTCF": {
 			"value": false,
-			"description": "Enable support for the IAB Transparency & Consent Framework",
+			"description": "Enable support for the IAB Transparency & Consent Framework. Ignored when CookieConsent is loaded, and when operating in Google Tag Manager mode.",
 			"descriptionmsg": "gtag-config-enabletcf"
 		},
 		"GTagHonorDNT": {
@@ -40,7 +40,8 @@
 		"main": {
 			"class": "MediaWiki\\Extension\\GTag\\Hooks",
 			"services": [
-				"PermissionManager"
+				"PermissionManager",
+				"ExtensionRegistry"
 			]
 		}
 	},

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -8,7 +8,7 @@
 	"gtag-desc": "Google Analytics Tracking",
 	"gtag-config-analyticsid": "Google Analytics account ID (GT-xxxxxxx or GTM-xxxxxxx)",
 	"gtag-config-anonymizeip": "Anonymize IP addresses sent to Google Analytics",
-	"gtag-config-enabletcf": "Enable support for the IAB Transparency & Consent Framework",
+	"gtag-config-enabletcf": "Enable support for the IAB Transparency & Consent Framework. Ignored when CookieConsent is loaded",
 	"gtag-config-honordnt": "Honor the DNT header indicating a user does not wish to be tracked",
 	"gtag-config-tracksensitivepages": "Include tracking code on potentially sensitive pages such as UserLogin and Preferences",
 	"right-gtag-exempt": "Not be tracked by Google Analytics"

--- a/src/Hooks.php
+++ b/src/Hooks.php
@@ -5,6 +5,7 @@ namespace MediaWiki\Extension\GTag;
 use MediaWiki\Hook\BeforePageDisplayHook;
 use MediaWiki\Html\Html;
 use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\Registration\ExtensionRegistry;
 use MediaWiki\ResourceLoader\Module;
 use OutputPage;
 use Skin;
@@ -13,11 +14,19 @@ class Hooks implements BeforePageDisplayHook {
 	/** @var PermissionManager */
 	private PermissionManager $permissionManager;
 
+	/** @var ExtensionRegistry */
+	private ExtensionRegistry $extensionRegistry;
+
 	/**
 	 * @param PermissionManager $permissionManager
+	 * @param ExtensionRegistry $extensionRegistry
 	 */
-	public function __construct( PermissionManager $permissionManager ) {
+	public function __construct(
+		PermissionManager $permissionManager,
+		ExtensionRegistry $extensionRegistry
+	) {
 		$this->permissionManager = $permissionManager;
+		$this->extensionRegistry = $extensionRegistry;
 	}
 
 	/**
@@ -34,8 +43,9 @@ class Hooks implements BeforePageDisplayHook {
 		$gaId = $config->get( 'GTagAnalyticsId' );
 		$anonymizeIP = $config->get( 'GTagAnonymizeIP' );
 		$honorDNT = $config->get( 'GTagHonorDNT' );
-		$enableTCF = $config->get( 'GTagEnableTCF' );
 		$trackSensitive = $config->get( 'GTagTrackSensitivePages' );
+		$cookieConsentLoaded = $this->extensionRegistry->isLoaded( 'CookieConsent' );
+		$enableTCF = $config->get( 'GTagEnableTCF' ) && !$cookieConsentLoaded;
 
 		$validId = preg_match( '/^(?<tagType>[A-Z]+)-[0-9A-Z-]+$/', $gaId, $matches );
 		if ( $gaId === '' || !$validId ) {
@@ -94,12 +104,26 @@ class Hooks implements BeforePageDisplayHook {
 		// If we get here, the user should be tracked
 		switch ( $matches['tagType'] ) {
 			case 'GTM':
-				$this->setupGTM( $gaId, $out );
+				$this->setupGTM( $gaId, $out, $cookieConsentLoaded );
 				break;
 			default:
-				$this->setupGtag( $gaId, $tcfLine, $gtConfigJson, $out );
+				$this->setupGtag( $gaId, $tcfLine, $gtConfigJson, $out, $cookieConsentLoaded );
 				break;
 		}
+	}
+
+	/**
+	 * Attributes that keep a script inert until CookieConsent grants statistics.
+	 *
+	 * @param OutputPage $out
+	 * @return array
+	 */
+	private function consentScriptAttribs( OutputPage $out ): array {
+		return [
+			'type' => 'text/plain',
+			'data-mw-cookieconsent' => 'statistics',
+			'nonce' => $out->getCSP()->getNonce(),
+		];
 	}
 
 	/**
@@ -107,25 +131,24 @@ class Hooks implements BeforePageDisplayHook {
 	 *
 	 * @param string $gaId
 	 * @param OutputPage $out
+	 * @param bool $cookieConsentLoaded
 	 * @return void
 	 */
-	private function setupGTM( string $gaId, OutputPage $out ): void {
-		$out->addInlineScript( <<<EOS
+	private function setupGTM( string $gaId, OutputPage $out, bool $cookieConsentLoaded ): void {
+		$loader = <<<EOS
 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
 j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
 'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
 })(window,document,'script','dataLayer','$gaId');
-EOS
-		);
+EOS;
 
-		$out->addHTML( <<<EOS
-<!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=$gaId"
-height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-<!-- End Google Tag Manager (noscript) -->
-EOS
-		);
+		if ( $cookieConsentLoaded ) {
+			$this->addConsentGuardedGtm( $loader, $out );
+			return;
+		}
+
+		$this->addUnguardedGtm( $gaId, $loader, $out );
 	}
 
 	/**
@@ -135,21 +158,96 @@ EOS
 	 * @param string $tcfLine
 	 * @param string $gtConfigJson
 	 * @param OutputPage $out
+	 * @param bool $cookieConsentLoaded
 	 * @return void
 	 */
-	private function setupGtag( string $gaId, string $tcfLine, string $gtConfigJson, OutputPage $out ): void {
+	private function setupGtag(
+		string $gaId,
+		string $tcfLine,
+		string $gtConfigJson,
+		OutputPage $out,
+		bool $cookieConsentLoaded
+	): void {
+		$inline = <<<EOS
+window.dataLayer = window.dataLayer || [];
+$tcfLine
+function gtag(){dataLayer.push(arguments);}
+gtag('js', new Date());
+gtag('config', '$gaId', $gtConfigJson);
+EOS;
+
+		if ( $cookieConsentLoaded ) {
+			$this->addConsentGuardedGtag( $gaId, $inline, $out );
+			return;
+		}
+
+		$this->addUnguardedGtag( $gaId, $inline, $out );
+	}
+
+	/**
+	 * Emit gtag.js tags that stay inert until CookieConsent grants statistics.
+	 *
+	 * @param string $gaId
+	 * @param string $inline
+	 * @param OutputPage $out
+	 * @return void
+	 */
+	protected function addConsentGuardedGtag( string $gaId, string $inline, OutputPage $out ): void {
+		$attribs = $this->consentScriptAttribs( $out );
+		$out->addScript( Html::element( 'script', $attribs + [
+			'src' => "https://www.googletagmanager.com/gtag/js?id=$gaId",
+			'async' => true,
+		] ) );
+		$out->addScript( Html::rawElement( 'script', $attribs, $inline ) );
+	}
+
+	/**
+	 * Emit live gtag.js tags.
+	 *
+	 * @param string $gaId
+	 * @param string $inline
+	 * @param OutputPage $out
+	 * @return void
+	 */
+	protected function addUnguardedGtag( string $gaId, string $inline, OutputPage $out ): void {
 		$out->addScript( Html::element( 'script', [
 			'src' => "https://www.googletagmanager.com/gtag/js?id=$gaId",
 			'async' => true,
 			'nonce' => $out->getCSP()->getNonce()
 		] ) );
 
-		$out->addInlineScript( <<<EOS
-window.dataLayer = window.dataLayer || [];
-$tcfLine
-function gtag(){dataLayer.push(arguments);}
-gtag('js', new Date());
-gtag('config', '$gaId', $gtConfigJson);
+		$out->addInlineScript( $inline );
+	}
+
+	/**
+	 * Emit a GTM loader that stays inert until CookieConsent grants statistics.
+	 *
+	 * CookieConsent needs JavaScript, so the GTM noscript iframe is omitted.
+	 *
+	 * @param string $loader
+	 * @param OutputPage $out
+	 * @return void
+	 */
+	protected function addConsentGuardedGtm( string $loader, OutputPage $out ): void {
+		$out->addScript( Html::rawElement( 'script', $this->consentScriptAttribs( $out ), $loader ) );
+	}
+
+	/**
+	 * Emit live GTM loader and noscript iframe.
+	 *
+	 * @param string $gaId
+	 * @param string $loader
+	 * @param OutputPage $out
+	 * @return void
+	 */
+	protected function addUnguardedGtm( string $gaId, string $loader, OutputPage $out ): void {
+		$out->addInlineScript( $loader );
+
+		$out->addHTML( <<<EOS
+<!-- Google Tag Manager (noscript) -->
+<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=$gaId"
+height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
+<!-- End Google Tag Manager (noscript) -->
 EOS
 		);
 	}

--- a/tests/phpunit/unit/HooksConsentTest.php
+++ b/tests/phpunit/unit/HooksConsentTest.php
@@ -1,0 +1,264 @@
+<?php
+
+namespace MediaWiki\Extension\GTag\Tests;
+
+use HashConfig;
+use MediaWiki\Extension\GTag\Hooks;
+use MediaWiki\Output\OutputPage;
+use MediaWiki\Permissions\PermissionManager;
+use MediaWiki\Registration\ExtensionRegistry;
+use MediaWiki\Request\ContentSecurityPolicy;
+use MediaWiki\Request\WebRequest;
+use MediaWiki\User\User;
+use MediaWikiUnitTestCase;
+use Skin;
+use Wikimedia\TestingAccessWrapper;
+
+/**
+ * @covers \MediaWiki\Extension\GTag\Hooks
+ */
+class HooksConsentTest extends MediaWikiUnitTestCase {
+
+	/**
+	 * @param array $configOverrides
+	 * @param bool $exempt
+	 * @param bool $cookieConsentLoaded
+	 * @return array{0:PermissionManager,1:ExtensionRegistry,2:OutputPage,3:Skin}
+	 */
+	private function pageFixtures(
+		array $configOverrides,
+		bool $exempt = false,
+		bool $cookieConsentLoaded = false
+	): array {
+		$config = new HashConfig( $configOverrides + [
+			'GTagAnalyticsId' => 'G-TEST1234',
+			'GTagAnonymizeIP' => false,
+			'GTagHonorDNT' => false,
+			'GTagEnableTCF' => false,
+			'GTagTrackSensitivePages' => true,
+		] );
+
+		$user = $this->createMock( User::class );
+		$request = $this->createMock( WebRequest::class );
+		$request->method( 'getHeader' )->willReturn( false );
+
+		$permissionManager = $this->createMock( PermissionManager::class );
+		$permissionManager->method( 'userHasRight' )->willReturn( $exempt );
+
+		$extensionRegistry = $this->createMock( ExtensionRegistry::class );
+		$extensionRegistry->method( 'isLoaded' )->willReturnCallback(
+			static function ( $name ) use ( $cookieConsentLoaded ) {
+				return $cookieConsentLoaded && $name === 'CookieConsent';
+			}
+		);
+
+		$csp = $this->createMock( ContentSecurityPolicy::class );
+		$csp->method( 'getNonce' )->willReturn( false );
+
+		$out = $this->createMock( OutputPage::class );
+		$out->method( 'getUser' )->willReturn( $user );
+		$out->method( 'getConfig' )->willReturn( $config );
+		$out->method( 'getRequest' )->willReturn( $request );
+		$out->method( 'getCSP' )->willReturn( $csp );
+
+		$skin = $this->createMock( Skin::class );
+
+		return [ $permissionManager, $extensionRegistry, $out, $skin ];
+	}
+
+	/**
+	 * @param PermissionManager $permissionManager
+	 * @param ExtensionRegistry $extensionRegistry
+	 * @return Hooks&\PHPUnit\Framework\MockObject\MockObject
+	 */
+	private function newRoutingMock(
+		PermissionManager $permissionManager,
+		ExtensionRegistry $extensionRegistry
+	): Hooks {
+		return $this->getMockBuilder( Hooks::class )
+			->setConstructorArgs( [ $permissionManager, $extensionRegistry ] )
+			->onlyMethods( [
+				'addConsentGuardedGtag',
+				'addUnguardedGtag',
+				'addConsentGuardedGtm',
+				'addUnguardedGtm',
+			] )
+			->getMock();
+	}
+
+	public static function provideConsentAndTcfCombinations(): array {
+		return [
+			'CookieConsent, TCF true' => [ true, true ],
+			'CookieConsent, TCF false' => [ true, false ],
+			'no CookieConsent, TCF false' => [ false, false ],
+			'no CookieConsent, TCF true' => [ false, true ],
+		];
+	}
+
+	/**
+	 * @dataProvider provideConsentAndTcfCombinations
+	 * @param bool $cookieConsentLoaded
+	 * @param bool $enableTCF
+	 */
+	public function testRoutingConsentAndTcfCombinations(
+		bool $cookieConsentLoaded,
+		bool $enableTCF
+	): void {
+		[ $permissionManager, $extensionRegistry, $out, $skin ] = $this->pageFixtures(
+			[ 'GTagEnableTCF' => $enableTCF ],
+			false,
+			$cookieConsentLoaded
+		);
+		$hooks = $this->newRoutingMock( $permissionManager, $extensionRegistry );
+
+		$hooks->expects( $this->never() )->method( 'addConsentGuardedGtm' );
+		$hooks->expects( $this->never() )->method( 'addUnguardedGtm' );
+
+		if ( $cookieConsentLoaded ) {
+			$hooks->expects( $this->once() )->method( 'addConsentGuardedGtag' )->with(
+				$this->anything(),
+				$this->logicalNot( $this->stringContains( 'gtag_enable_tcf_support' ) ),
+				$this->anything()
+			);
+			$hooks->expects( $this->never() )->method( 'addUnguardedGtag' );
+		} elseif ( $enableTCF ) {
+			$hooks->expects( $this->never() )->method( 'addConsentGuardedGtag' );
+			$hooks->expects( $this->once() )->method( 'addUnguardedGtag' )->with(
+				$this->anything(),
+				$this->stringContains( 'gtag_enable_tcf_support' ),
+				$this->anything()
+			);
+		} else {
+			$hooks->expects( $this->never() )->method( 'addConsentGuardedGtag' );
+			$hooks->expects( $this->once() )->method( 'addUnguardedGtag' )->with(
+				$this->anything(),
+				$this->logicalNot( $this->stringContains( 'gtag_enable_tcf_support' ) ),
+				$this->anything()
+			);
+		}
+
+		$hooks->onBeforePageDisplay( $out, $skin );
+	}
+
+	public function testRoutingCookieConsentGtmUsesGuardedEmitter() {
+		[ $permissionManager, $extensionRegistry, $out, $skin ] = $this->pageFixtures(
+			[ 'GTagAnalyticsId' => 'GTM-TEST1234' ],
+			false,
+			true
+		);
+		$hooks = $this->newRoutingMock( $permissionManager, $extensionRegistry );
+
+		$hooks->expects( $this->once() )->method( 'addConsentGuardedGtm' );
+		$hooks->expects( $this->never() )->method( 'addUnguardedGtm' );
+		$hooks->expects( $this->never() )->method( 'addConsentGuardedGtag' );
+		$hooks->expects( $this->never() )->method( 'addUnguardedGtag' );
+
+		$hooks->onBeforePageDisplay( $out, $skin );
+	}
+
+	public function testRoutingNoAnalyticsIdDoesNotEmitTags() {
+		[ $permissionManager, $extensionRegistry, $out, $skin ] = $this->pageFixtures(
+			[ 'GTagAnalyticsId' => '' ],
+			false,
+			true
+		);
+		$hooks = $this->newRoutingMock( $permissionManager, $extensionRegistry );
+
+		$hooks->expects( $this->never() )->method( 'addConsentGuardedGtag' );
+		$hooks->expects( $this->never() )->method( 'addUnguardedGtag' );
+		$hooks->expects( $this->never() )->method( 'addConsentGuardedGtm' );
+		$hooks->expects( $this->never() )->method( 'addUnguardedGtm' );
+
+		$hooks->onBeforePageDisplay( $out, $skin );
+	}
+
+	public function testConsentGuardedGtagEmitsPlainTags() {
+		[ $permissionManager, $extensionRegistry, $out ] = $this->pageFixtures( [] );
+		$hooks = TestingAccessWrapper::newFromObject(
+			new Hooks( $permissionManager, $extensionRegistry )
+		);
+
+		$out->expects( $this->exactly( 2 ) )->method( 'addScript' )->withConsecutive(
+			[
+				$this->logicalAnd(
+					$this->stringContains( 'type="text/plain"' ),
+					$this->stringContains( 'data-mw-cookieconsent="statistics"' ),
+					$this->stringContains( 'gtag/js?id=G-TEST1234' )
+				),
+			],
+			[
+				$this->logicalAnd(
+					$this->stringContains( 'type="text/plain"' ),
+					$this->stringContains( 'data-mw-cookieconsent="statistics"' ),
+					$this->stringContains( 'dataLayer' ),
+					$this->logicalNot( $this->stringContains( 'gtag_enable_tcf_support' ) )
+				),
+			]
+		);
+		$out->expects( $this->never() )->method( 'addInlineScript' );
+
+		$hooks->addConsentGuardedGtag( 'G-TEST1234', "window.dataLayer = window.dataLayer || [];\n", $out );
+	}
+
+	public function testUnguardedGtagEmitsLiveTagsAndTcfLine() {
+		[ $permissionManager, $extensionRegistry, $out ] = $this->pageFixtures( [] );
+		$hooks = TestingAccessWrapper::newFromObject(
+			new Hooks( $permissionManager, $extensionRegistry )
+		);
+
+		$out->expects( $this->once() )->method( 'addScript' )->with(
+			$this->logicalAnd(
+				$this->stringContains( 'gtag/js?id=G-TEST1234' ),
+				$this->logicalNot( $this->stringContains( 'text/plain' ) )
+			)
+		);
+		$out->expects( $this->once() )->method( 'addInlineScript' )->with(
+			$this->stringContains( 'gtag_enable_tcf_support' )
+		);
+
+		$hooks->addUnguardedGtag(
+			'G-TEST1234',
+			"window[\"gtag_enable_tcf_support\"] = true;\n",
+			$out
+		);
+	}
+
+	public function testConsentGuardedGtmOmitsIframe() {
+		[ $permissionManager, $extensionRegistry, $out ] = $this->pageFixtures( [] );
+		$hooks = TestingAccessWrapper::newFromObject(
+			new Hooks( $permissionManager, $extensionRegistry )
+		);
+
+		$out->expects( $this->once() )->method( 'addScript' )->with(
+			$this->logicalAnd(
+				$this->stringContains( 'type="text/plain"' ),
+				$this->stringContains( 'data-mw-cookieconsent="statistics"' ),
+				$this->stringContains( 'GTM-TEST1234' )
+			)
+		);
+		$out->expects( $this->never() )->method( 'addInlineScript' );
+		$out->expects( $this->never() )->method( 'addHTML' );
+
+		$hooks->addConsentGuardedGtm( "gtm.js?id=GTM-TEST1234\n", $out );
+	}
+
+	public function testUnguardedGtmEmitsNoscriptIframe() {
+		[ $permissionManager, $extensionRegistry, $out ] = $this->pageFixtures( [] );
+		$hooks = TestingAccessWrapper::newFromObject(
+			new Hooks( $permissionManager, $extensionRegistry )
+		);
+
+		$out->expects( $this->once() )->method( 'addInlineScript' )->with(
+			$this->stringContains( 'GTM-TEST1234' )
+		);
+		$out->expects( $this->once() )->method( 'addHTML' )->with(
+			$this->logicalAnd(
+				$this->stringContains( '<noscript>' ),
+				$this->stringContains( 'googletagmanager.com/ns.html?id=GTM-TEST1234' )
+			)
+		);
+		$out->expects( $this->never() )->method( 'addScript' );
+
+		$hooks->addUnguardedGtm( 'GTM-TEST1234', "gtm.js?id=GTM-TEST1234\n", $out );
+	}
+}


### PR DESCRIPTION
When [CookieConsent](https://www.mediawiki.org/wiki/Extension:CookieConsent) is loaded, GTag emits Google scripts as `type="text/plain"` with `data-mw-cookieconsent="statistics"`. CookieConsent turns them on after statistics consent. Without CookieConsent, nothing changes.

CookieConsent needs JavaScript, so GTM does not output the noscript iframe in this mode. `$wgGTagEnableTCF` is ignored when CookieConsent is loaded.